### PR TITLE
Upgrade Zoom Meeting Windows SDK to version 5.12.8.10282

### DIFF
--- a/virtual-participant-orchestrator-for-zoom-meeting/README.md
+++ b/virtual-participant-orchestrator-for-zoom-meeting/README.md
@@ -77,14 +77,14 @@ The virtual participant runs as a Windows app built ontop of Zoom Meeting Window
 
 ### Apply Zoom SDK Patch
 
-1. Download the `zoom-sdk-windows-5.11.1.6653.zip` code archive from the [Zoom App Marketplace](https://marketplace.zoom.us/docs/sdk/native-sdks/windows/).
+1. Download the `zoom-sdk-windows-5.12.8.10282.zip` code archive from the [Zoom App Marketplace](https://marketplace.zoom.us/docs/sdk/native-sdks/windows/).
 
-2. Unzip the code archive to the `src` directory, so there is a `src/zoom-sdk-windows-5.11.1.6653` path.
+2. Unzip the code archive to the `src` directory, so there is a `src/zoom-sdk-windows-5.12.8.10282` path.
 
 3. Apply the Zoom Windows SDK patch:
 
     ```
-    git apply -p1 --directory src/zoom-sdk-windows-5.11.1.6653 --verbose --reject --whitespace=fix src/zoom_sdk_demo_v2.patch
+    git apply -p1 --directory src/zoom-sdk-windows-5.12.8.10282 --verbose --reject --whitespace=fix src/zoom_sdk_demo_v2.patch
     ```
 
 ### Package CloudFormation Template

--- a/virtual-participant-orchestrator-for-zoom-meeting/src/Dockerfile
+++ b/virtual-participant-orchestrator-for-zoom-meeting/src/Dockerfile
@@ -83,7 +83,7 @@ RUN vcpkg\vcpkg install "aws-sdk-cpp[sns]" --recurse --triplet x64-windows
 RUN vcpkg\vcpkg integrate install
 
 # ===== Copy Windows Zoom SDK code =========================================================================
-COPY zoom-sdk-windows-5.11.1.6653 /opt/zoom-sdk-windows-5.11.1.6653
+COPY zoom-sdk-windows-5.12.8.10282 /opt/zoom-sdk-windows-5.12.8.10282
 
 # ===== Build Windows Zoom SDK code ========================================================================
 WORKDIR /opt/
@@ -107,7 +107,7 @@ RUN `
   # Cleanup
   && del /q vs_buildtools.exe
 
-COPY --from=builder C:\opt\zoom-sdk-windows-5.11.1.6653\x64\bin /opt/bin
+COPY --from=builder C:\opt\zoom-sdk-windows-5.12.8.10282\x64\bin /opt/bin
 COPY --from=builder C:\opt\amazon-kinesis-video-streams-producer-sdk-cpp /opt/amazon-kinesis-video-streams-producer-sdk-cpp
 
 # ===== Set required environment variables =================================================================

--- a/virtual-participant-orchestrator-for-zoom-meeting/src/README.md
+++ b/virtual-participant-orchestrator-for-zoom-meeting/src/README.md
@@ -56,17 +56,17 @@ The virtual participant runs as a Windows app built ontop of Zoom Meeting Window
 ### Apply Zoom SDK patch
 If you haven't completed this step from the parent directory instructions
 
-1. Download `zoom-sdk-windows-5.11.1.6653.zip` from the [Zoom App Marketplace](https://marketplace.zoom.us/docs/sdk/native-sdks/windows/)
-2. Unzip the code archive to the this directory, so there is a **zoom-sdk-windows-5.11.1.6653** directory here.
+1. Download `zoom-sdk-windows-5.12.8.10282.zip` from the [Zoom App Marketplace](https://marketplace.zoom.us/docs/sdk/native-sdks/windows/)
+2. Unzip the code archive to the this directory, so there is a **zoom-sdk-windows-5.12.8.10282** directory here.
 3. Verify that you can successfully run 
 
 	```
-	dir zoom-sdk-windows-5.11.1.6653
+	dir zoom-sdk-windows-5.12.8.10282
 	```
 4. Apply the Zoom Windows SDK patch:
 
     ```
-    git apply -p1 --directory zoom-sdk-windows-5.11.1.6653 --verbose --reject --whitespace=fix zoom_sdk_demo_v2.patch
+    git apply -p1 --directory zoom-sdk-windows-5.12.8.10282 --verbose --reject --whitespace=fix zoom_sdk_demo_v2.patch
     ``` 
 
 
@@ -172,7 +172,7 @@ ZOOM_APP_SECRET=<Zoom SDK SECRET from Zoom App Marketplace>
 
 To test the functionality of the applicaiton perform the following tasks:
 
-1. In Visual Studio open the solution in `zoom-sdk-windows-5.11.1.6653\x64\demo\sdk_demo_v2` directory
+1. In Visual Studio open the solution in `zoom-sdk-windows-5.12.8.10282\x64\demo\sdk_demo_v2` directory
 2. Choose **"Release"** and **"x64"** configuration and build solution. 
 3. Launch application with debugger (shortcut: F5) and accept network access.
 4. If Zoom app SDK credentials are ok you should see the following dialog:

--- a/virtual-participant-orchestrator-for-zoom-meeting/src/build_zoom_app.bat
+++ b/virtual-participant-orchestrator-for-zoom-meeting/src/build_zoom_app.bat
@@ -3,5 +3,5 @@ if defined DOCKER_BUILD (
 ) else (
     call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 )
-cd zoom-sdk-windows-5.11.1.6653\x64\demo\sdk_demo_v2\
+cd zoom-sdk-windows-5.12.8.10282\x64\demo\sdk_demo_v2\
 msbuild sdk_demo_v2.vcxproj /p:configuration=release /p:platform=x64 

--- a/virtual-participant-orchestrator-for-zoom-meeting/src/zoom_sdk_demo_v2.patch
+++ b/virtual-participant-orchestrator-for-zoom-meeting/src/zoom_sdk_demo_v2.patch
@@ -1889,16 +1889,16 @@ index e270f52..b935e2a 100644
      <IntDir>$(Configuration)\</IntDir>
      <LinkIncremental>false</LinkIncremental>
      <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-+    <IncludePath>C:\opt\zoom-sdk-windows-5.11.1.6653\zoom-sdk-windows-5.11.1.6653\x64\h;$(IncludePath)</IncludePath>
-+    <LibraryPath>C:\opt\zoom-sdk-windows-5.11.1.6653\zoom-sdk-windows-5.11.1.6653\x64\lib;$(LibraryPath)</LibraryPath>
++    <IncludePath>C:\opt\zoom-sdk-windows-5.12.8.10282\zoom-sdk-windows-5.12.8.10282\x64\h;$(IncludePath)</IncludePath>
++    <LibraryPath>C:\opt\zoom-sdk-windows-5.12.8.10282\zoom-sdk-windows-5.12.8.10282\x64\lib;$(LibraryPath)</LibraryPath>
    </PropertyGroup>
    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
      <OutDir>..\..\bin\</OutDir>
      <IntDir>$(Configuration)\</IntDir>
      <LinkIncremental>false</LinkIncremental>
      <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-+    <IncludePath>C:\opt\zoom-sdk-windows-5.11.1.6653\zoom-sdk-windows-5.11.1.6653\x64\h;$(IncludePath)</IncludePath>
-+    <LibraryPath>C:\opt\zoom-sdk-windows-5.11.1.6653\zoom-sdk-windows-5.11.1.6653\x64\lib;$(LibraryPath)</LibraryPath>
++    <IncludePath>C:\opt\zoom-sdk-windows-5.12.8.10282\zoom-sdk-windows-5.12.8.10282\x64\h;$(IncludePath)</IncludePath>
++    <LibraryPath>C:\opt\zoom-sdk-windows-5.12.8.10282\zoom-sdk-windows-5.12.8.10282\x64\lib;$(LibraryPath)</LibraryPath>
    </PropertyGroup>
    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
      <ClCompile>
@@ -2210,52 +2210,3 @@ index 8c86583..bf2ed05 100644
 +#include <sstream>
 +#include <stdint.h>
 +#include "sdk_util.h"
-diff --git a/x64/h/meeting_service_interface.h b/x64/h/meeting_service_interface.h
-index 38972a9..34969ae 100644
---- a/x64/h/meeting_service_interface.h
-+++ b/x64/h/meeting_service_interface.h
-@@ -141,6 +141,7 @@ typedef struct tagJoinParam4WithoutLogin
- 	bool		   isDirectShareDesktop;///<Share the desktop directly or not. True indicates to Share.
- 	bool		   isVideoOff;///<Turn off the video of not. True indicates to turn off. In addition, this flag is affected by meeting attributes.
- 	bool		   isAudioOff;///<Turn off the audio or not. True indicates to turn off. In addition, this flag is affected by meeting attributes.
-+	const wchar_t* join_token;///<join token.
- }JoinParam4WithoutLogin;
- 
- /*! \struct tagJoinParam4NormalUser
-diff --git a/x64/h/rawdata/rawdata_share_source_helper_interface.h b/x64/h/rawdata/rawdata_share_source_helper_interface.h
-new file mode 100644
-index 0000000..889e59c
---- /dev/null
-+++ b/x64/h/rawdata/rawdata_share_source_helper_interface.h
-@@ -0,0 +1,30 @@
-+#ifndef _RAWDATA_SHARE_SOURCE_HELPER_INTERFACE_H_
-+#define _RAWDATA_SHARE_SOURCE_HELPER_INTERFACE_H_
-+#include "zoom_sdk_def.h"
-+
-+BEGIN_ZOOM_SDK_NAMESPACE
-+
-+class IZoomSDKShareSender
-+{
-+public:
-+	virtual ~IZoomSDKShareSender() {}
-+	virtual SDKError sendShareFrame(char* frameBuffer, int width, int height, int frameLength) = 0;
-+};
-+
-+class IZoomSDKShareSource
-+{
-+public:
-+	virtual ~IZoomSDKShareSource() {}
-+	virtual void onStartSend(IZoomSDKShareSender* pSender) = 0;
-+	virtual void onStopSend() = 0;
-+};
-+
-+class IZoomSDKShareSourceHelper
-+{
-+public:
-+	virtual ~IZoomSDKShareSourceHelper() {}
-+	virtual SDKError setExternalShareSource(IZoomSDKShareSource* pShareSource) = 0;
-+};
-+
-+END_ZOOM_SDK_NAMESPACE
-+#endif
-\ No newline at end of file


### PR DESCRIPTION
Fix #10 issue - previous sdk version can no longer join meetings as of may 6, 2023

- replaced all instances of 5.11.1.6653 with 5.12.8.10282
- removed rawdata_share_source_helper_interface.h and meeting_service_interface.h from patch since they are included in the new version of the sdk

### A reference to a related issue in your repository.

ANSWER: 

#10 

### A description of the changes proposed in the pull request.

ANSWER:

Forced upgrade to a minimum acceptable SDK version.  Verified patch on local machine. VPF can join meetings
and stream audio to KVS

### @mentions of the person or team responsible for reviewing proposed changes.

ANSWER:

None
