### PR TITLE
Freeze version of vcpkg to 2023.02.24 release

### DIFF
--- a/virtual-participant-orchestrator-for-zoom-meeting/src/Dockerfile
+++ b/virtual-participant-orchestrator-for-zoom-meeting/src/Dockerfile
@@ -73,7 +73,7 @@ RUN setx /M PATH "%PATH%;C:\opt\amazon-kinesis-video-streams-producer-sdk-cpp\op
 
 # ===== Install vcpkg ======================================================================================
 WORKDIR /opt/
-RUN git clone https://github.com/Microsoft/vcpkg.git
+RUN git clone --depth 1 --branch 2023.02.24 https://github.com/Microsoft/vcpkg.git
 RUN call .\vcpkg\bootstrap-vcpkg.bat
 
 # ===== Install vcpkg packages =============================================================================


### PR DESCRIPTION
Fix issue #12  - Caused by vcpkg regression in lastest release (2023.04.15) and the master branch

- updated docker file to clone vcpkg from tag 2023.02.24

### A reference to a related issue in your repository.


ANSWER:


### A description of the changes proposed in the pull request.


ANSWER:

### @mentions of the person or team responsible for reviewing proposed changes.

ANSWER:


