### PR TITLE
update Readmes - EOL feb 3, 2024 notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a sample solutions umbrella project for building AI powered virtual participants for Real-Time Communication (RTC) services like Zoom. This repository is under development.
 
+> :warning: The Zoom Meeting sample **IS NO LONGER Functional**. As of Feb 3, 2024 the version of the Zoom Meeting Windows SDK used as a dependency is no longer compatible with Zoom Service. This means the sample app (i.e. the bot application that is created by Virtual Patricipant Framework) can no longer join a Zoom meeting as a participant.  Unfortunately newer versions of the Zoom Meeting Windows SDK wrappend in a Docker container can no longer stream media to Amazon Kinesis Video Stream rendering them incompatible with the sample. After a lengthy investigation we have not been able to resolve the compatiblity issue, highlighting the fragility of this sample solution. This bring our Virtual Participant Framework sample and the experiment to End of Life.  For any community support or questions please connect with the Zoom developer ecosystem team via the [Zoom Developer Forum](https://devforum.zoom.us/).
+
 ## Project Directory
 * [Virtual Participant Orcestrator for Zoom Meeting](virtual-participant-orchestrator-for-zoom-meeting/README.md) [Ready for dev/test]
 

--- a/virtual-participant-orchestrator-for-zoom-meeting/README.md
+++ b/virtual-participant-orchestrator-for-zoom-meeting/README.md
@@ -1,5 +1,7 @@
 # Virtual Participant Orchestrator for Zoom Meeting
 
+> :warning: The Zoom Meeting sample **IS NO LONGER Functional**. As of Feb 3, 2024 the version of the Zoom Meeting Windows SDK used as a dependency is no longer compatible with Zoom Service. This means the sample app (i.e. the bot application that is created by Virtual Patricipant Framework) can no longer join a Zoom meeting as a participant.  Unfortunately newer versions of the Zoom Meeting Windows SDK wrappend in a Docker container can no longer stream media to Amazon Kinesis Video Stream rendering them incompatible with the sample. After a lengthy investigation we have not been able to resolve the compatiblity issue, highlighting the fragility of this sample solution. This bring our Virtual Participant Framework sample and the experiment to End of Life.  For any community support or questions please connect with the Zoom developer ecosystem team via the [Zoom Developer Forum](https://devforum.zoom.us/).
+
 ## About
 
 This virtual participant orchestrator for Zoom Meeting is developed by AWS Prototyping and Cloud Engineering (PACE) team and Solutions Architects. The objectives of this prototype include:

--- a/virtual-participant-orchestrator-for-zoom-meeting/src/README.md
+++ b/virtual-participant-orchestrator-for-zoom-meeting/src/README.md
@@ -1,5 +1,8 @@
 # Zoom Meeting virtual participant application
 
+
+> :warning: The Zoom Meeting sample **IS NO LONGER Functional**. As of Feb 3, 2024 the version of the Zoom Meeting Windows SDK used as a dependency is no longer compatible with Zoom Service. This means the sample app (i.e. the bot application that is created by Virtual Patricipant Framework) can no longer join a Zoom meeting as a participant.  Unfortunately newer versions of the Zoom Meeting Windows SDK wrappend in a Docker container can no longer stream media to Amazon Kinesis Video Stream rendering them incompatible with the sample. After a lengthy investigation we have not been able to resolve the compatiblity issue, highlighting the fragility of this sample solution. This bring our Virtual Participant Framework sample and the experiment to End of Life.  For any community support or questions please connect with the Zoom developer ecosystem team via the [Zoom Developer Forum](https://devforum.zoom.us/).
+
 ## About
 
 This is a subproject of the AWS virtual participant framework for Zoom Meeting. It contains the artifacts needed to build virtual participant Windows applications using the Zoom Meeting Windows SDK which can be downloaded from the [Zoom App Marketplace](https://marketplace.zoom.us/docs/sdk/native-sdks/windows/).


### PR DESCRIPTION
### A reference to a related issue in your repository.


ANSWER:
Related to #21. After months of investigation, the dockerized Zoom Meeting Windows SDK versions 5.14+ cannot stream media to KVS. This renders the sample non-functional since older SDK versions are below min version requirement by Zoom.

### A description of the changes proposed in the pull request.


ANSWER:

Added End of Life Notice

### @mentions of the person or team responsible for reviewing proposed changes.

ANSWER:

@chrislott 
